### PR TITLE
Messing with npm

### DIFF
--- a/install_ec2.sh
+++ b/install_ec2.sh
@@ -8,19 +8,21 @@ sudo apt-get install docker-ce
 sudo systemctl start docker
 sudo groupadd docker
 sudo usermod -aG docker ubuntu
-#Install Node > 19.0, to make editorconfig work
+
+# Install Node > 19.0, to make editorconfig / prettier etc. work
 curl -fsSL https://deb.nodesource.com/setup_19.x | sudo -E bash - &&\
 sudo apt-get install -y nodejs
 sudo apt-get install -y npm
 
-#Setup actions to be able to write to certain directories when installing libraries
+# Setup actions to be able to write to certain directories when installing libraries
 sudo chmod -R 777 /usr/local/lib
-sudo chmod -R 777 /usr/local/bin/prettier
+sudo chmod -R 777 /usr/local/bin
 sudo chmod -R 777 /usr/lib
 
-#install conda
+# Install conda
 wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh
-#install singularity
+
+# Install singularity
 sudo apt-get update && sudo apt-get install -y \
     build-essential \
     uuid-dev \
@@ -35,22 +37,25 @@ sudo apt-get update && sudo apt-get install -y \
     openjdk-18-jre-headless
 wget https://github.com/sylabs/singularity/releases/download/v3.11.1/singularity-ce_3.11.1-jammy_amd64.deb
 sudo dpkg -i singularity-ce_3.11.1-jammy_amd64.deb
-#PHP Composer for website stuff
+
+# PHP Composer for website stuff
 sudo apt install php-cli unzip 
 curl -sS https://getcomposer.org/installer -o /tmp/composer-setup.php
 sudo php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer
 
-#Run this part of the script after adding a new user "runner" who should be made part of usergroup(s) docker and sudo to be able to run the services!
+#
+# Run this part of the script after adding a new user "runner"
+# who should be made part of usergroup(s) docker and sudo to be able to run the services!
+#
 
-#Add "runner" user, change to it and add it to the required groups, work needs to be in the same directory as on regular GHA runners
+# Add "runner" user, change to it and add it to the required groups, work needs to be in the same directory as on regular GHA runners
 sudo useradd runnner
 sudo usermod -a -G docker runner
 
-#Change to runner user
+# Change to runner user
 sudo su runner
-#Force npm to install to .local
-npm config set prefix '~/.local/'
-#Add it to path
-export PATH=$PATH:/home/runner/.local/bin
 
-#Continue with the regular setup under user runner and make sure work is in the home of runner as written in the readme file
+# Set the npm prefix
+npm config set prefix /usr/local
+
+# Continue with the regular setup under user runner and make sure work is in the home of runner as written in the readme file


### PR DESCRIPTION
Not totally sure about this, so want to check via a PR.

Context: Actions run such as [this](https://github.com/nf-core/nf-co.re/actions/runs/4531199448/jobs/7981062177)

<img width="836" alt="image" src="https://user-images.githubusercontent.com/465550/227935724-004fe3ce-1447-48cc-990e-2d5c54429e80.png">

```
Run prettier --check ${GITHUB_WORKSPACE}
  prettier --check ${GITHUB_WORKSPACE}
  shell: /usr/bin/bash -e {0}
/home/runner/work/_temp/b96948f7-6f81-4198-adee-e9[2](https://github.com/nf-core/nf-co.re/actions/runs/4531199448/jobs/7981062177#step:5:2)e[3](https://github.com/nf-core/nf-co.re/actions/runs/4531199448/jobs/7981062177#step:5:3)5e1[4](https://github.com/nf-core/nf-co.re/actions/runs/4531199448/jobs/7981062177#step:5:5)ba9.sh: line 1: prettier: command not found
Error: Process completed with exit code 127.
```

Logging into the EC2 instance as the `runner` user and doing:

```
npm config set prefix /usr/local
npm install -g prettier
```

seems to have fixed it. Hence my proposed changes here.

Sort of fumbling in the dark here though, would be curious about the previous prefix logic which I didn't see until now @apeltzer 